### PR TITLE
Fix issue with research points being lost

### DIFF
--- a/1.4/Source/RitualOutcomeEffectWorkers/RitualOutcomeEffectWorker_TribalGathering.cs
+++ b/1.4/Source/RitualOutcomeEffectWorkers/RitualOutcomeEffectWorker_TribalGathering.cs
@@ -89,7 +89,7 @@ namespace VFETribals
                     && activeResearches.Contains(Find.ResearchManager.currentProj))
                 {
                     totalResearchPoints -= totalResearchPoints / 2;
-                    Find.ResearchManager.progress[Find.ResearchManager.currentProj] += totalResearchPoints / 2;
+                    Find.ResearchManager.progress[Find.ResearchManager.currentProj] += totalResearchPoints;
                     if (Find.ResearchManager.currentProj.IsFinished)
                     {
                         Find.ResearchManager.FinishProject(Find.ResearchManager.currentProj, doCompletionDialog: false, null);


### PR DESCRIPTION
Theres a small issue with the allocation of research points after a tribal gathering if the player has selected an animal tech level research project. Currently points are allocated in this way:
- 1/2 are randomly assigned (intended)
- 1/4 are assigned to the selected project (should be 1/2)
- 1/4 are lost (unintended)

This bug occurred because the `totalResearchPoints` is reduced to half of its normal value (line 91) and then reduced by a further half when calculating the number of points to assign to the selected project (line 92). By removing the extra division, the selected project gets 1/2 of the points and the remaining 1/2 gets points randomly as intended.