### PR TITLE
Prevent loss of research points when only 1 tech avaliable

### DIFF
--- a/1.4/Source/RitualOutcomeEffectWorkers/RitualOutcomeEffectWorker_TribalGathering.cs
+++ b/1.4/Source/RitualOutcomeEffectWorkers/RitualOutcomeEffectWorker_TribalGathering.cs
@@ -86,7 +86,7 @@ namespace VFETribals
                 }
 
                 ResearchProjectDef currentProj = Find.ResearchManager.currentProj;
-                if (currentProj != null && currentProj.techLevel < TechLevel.Neolithic && activeResearches.Contains(currentProj))
+                if (currentProj != null && currentProj.techLevel < TechLevel.Neolithic && activeResearches.Count > 1 && activeResearches.Contains(currentProj))
                 {
                     totalResearchPoints -= totalResearchPoints / 2;
                     if (Prefs.DevMode)


### PR DESCRIPTION
Another patch for research points being lost accidentally when a research project is selected.

If the player only has one valid research they can perform within their tech level and that project is selected in the research manager, currently 1/2 the points will go that that project. Meanwhile the other 1/2 will be lost due to there being no other projects to assign those points to.

This change simply ensures there are at least 2 valid research projects available before assigning points to the selected project. This means if there is only one option, all points will go to it as intended. 