### PR TITLE
Fix compatibility issues due to ModsConfig.IsActive

### DIFF
--- a/1.4/Source/ModCompatibility.cs
+++ b/1.4/Source/ModCompatibility.cs
@@ -5,6 +5,6 @@ namespace VFETribals
     [StaticConstructorOnStartup]
     public static class ModCompatibility
     {
-        public static bool VFEClassicalActive = ModsConfig.IsActive("OskarPotocki.VFE.Classical");
+        public static bool VFEClassicalActive = ModsConfig.IsActive("OskarPotocki.VFE.Classical") || ModsConfig.IsActive("OskarPotocki.VFE.Classical_steam");
     }
 }


### PR DESCRIPTION
The issue occurs when checking if a mod is active with `ModsConfig.IsActive` when running the workshop version of a mod while there's a local copy in the mods directory. In those cases the `ModsConfig.IsActive` will return false as the running mod will have the `_steam` postfix.

The simple fix is to simply check for mod ID, as well as the mod ID with the `_steam` postfix.

For related PRs, check:
Vanilla-Expanded/VanillaExpandedFramework#72