### PR TITLE
Fixes and improvements to ChoiceLetter_WildMenJoin

### DIFF
--- a/1.4/Source/UI/ChoiceLetter_WildMenJoin.cs
+++ b/1.4/Source/UI/ChoiceLetter_WildMenJoin.cs
@@ -9,6 +9,9 @@ namespace VFETribals
     {
         public List<Pawn> wildmen;
         public Map map;
+
+        public override bool CanDismissWithRightClick => false;
+
         public override IEnumerable<DiaOption> Choices
         {
             get
@@ -23,7 +26,7 @@ namespace VFETribals
                         }
                         IncidentParms parms = new IncidentParms
                         {
-                            target = Find.CurrentMap
+                            target = map
                         };
                         PawnsArrivalModeDef edgeWalkIn = PawnsArrivalModeDefOf.EdgeWalkIn;
                         edgeWalkIn.Worker.TryResolveRaidSpawnCenter(parms);
@@ -57,6 +60,14 @@ namespace VFETribals
         {
             Find.Archive.Remove(this);
             Find.LetterStack.RemoveLetter(this);
+        }
+
+        public override void ExposeData()
+        {
+            base.ExposeData();
+        
+            Scribe_References.Look(ref map, "map");
+            Scribe_Collections.Look(ref wildmen, "wildmen", LookMode.Reference);
         }
     }
 }


### PR DESCRIPTION
Preventing right click dismiss will force the player to make a choice. Currently the player can dismiss the letter without any repercussions, avoiding either taking extra pawns or risking the raid chance. They'd still be able to return to the letter at any time in the future as well. An additional change that could be done here (but I haven't done it) would be to set a timeout as well which would force the player to make a choice in a timely manner.

Using the `map` field instead of `Find.CurrentMap` was done mostly for consistency. The rejection raid will hit a specific player settlement, while accepting the pawns can be done at any map whatsoever (including temporary quest maps).

Exposing data (namely the list of pawns and the map) should fix the issues caused by saving and reloading the game. Without those changes, saving and reloading would cause the player to be unable to accept the pawns (as they were not saved), and rejecting had a chance to cause an error as well (in case a raid was chosen), but that option could be repeatedly picked until successfully declining.

The errors (which are fixed by exposing data):

Accepting
```
Exception filling window for RimWorld.Dialog_NodeTreeWithFactionInfo: System.NullReferenceException: Object reference not set to an instance of an object
  at VFETribals.ChoiceLetter_WildMenJoin.<get_Choices>b__3_0 () [0x00000] in <01c1e3af6a0644b19108082ef0dc083d>:0 
  at Verse.DiaOption.Activate () [0x00038] in <cd7169108ea74757aa50c5b33d275c15>:0 
  at Verse.DiaOption.OptOnGUI (UnityEngine.Rect rect, System.Boolean active) [0x000ac] in <cd7169108ea74757aa50c5b33d275c15>:0 
  at Verse.Dialog_NodeTree.DrawNode (UnityEngine.Rect rect) [0x0014e] in <cd7169108ea74757aa50c5b33d275c15>:0 
  at Verse.Dialog_NodeTree.DoWindowContents (UnityEngine.Rect inRect) [0x0006e] in <cd7169108ea74757aa50c5b33d275c15>:0 
  at RimWorld.Dialog_NodeTreeWithFactionInfo.DoWindowContents (UnityEngine.Rect inRect) [0x00000] in <cd7169108ea74757aa50c5b33d275c15>:0 
  at Verse.Window.InnerWindowOnGUI (System.Int32 x) [0x001d3] in <cd7169108ea74757aa50c5b33d275c15>:0
```

Rejecting
```
Exception filling window for RimWorld.Dialog_NodeTreeWithFactionInfo: System.NullReferenceException: Object reference not set to an instance of an object
  at VFETribals.Utils.MakeWildmenRaid (System.Collections.Generic.List`1[T] wildmen, Verse.Map map, Verse.TaggedString letterLabel, Verse.TaggedString letterText) [0x00006] in <903f62577cc4455daf187cf57b55fa26>:0 
  at VFETribals.ChoiceLetter_WildMenJoin.<get_Choices>b__5_1 () [0x0000c] in <903f62577cc4455daf187cf57b55fa26>:0 
  at Verse.DiaOption.Activate () [0x00038] in <cd7169108ea74757aa50c5b33d275c15>:0 
  at Verse.DiaOption.OptOnGUI (UnityEngine.Rect rect, System.Boolean active) [0x000ac] in <cd7169108ea74757aa50c5b33d275c15>:0 
  at Verse.Dialog_NodeTree.DrawNode (UnityEngine.Rect rect) [0x0014e] in <cd7169108ea74757aa50c5b33d275c15>:0 
  at Verse.Dialog_NodeTree.DoWindowContents (UnityEngine.Rect inRect) [0x0006e] in <cd7169108ea74757aa50c5b33d275c15>:0 
  at RimWorld.Dialog_NodeTreeWithFactionInfo.DoWindowContents (UnityEngine.Rect inRect) [0x00000] in <cd7169108ea74757aa50c5b33d275c15>:0 
  at Verse.Window.InnerWindowOnGUI (System.Int32 x) [0x001d3] in <cd7169108ea74757aa50c5b33d275c15>:0
```