### PR TITLE
Small improvements to large fire

### DIFF
--- a/1.4/Source/GameComponents/GameComponent_Tribals.cs
+++ b/1.4/Source/GameComponents/GameComponent_Tribals.cs
@@ -52,7 +52,15 @@ namespace VFETribals
                 lastLargeFireUpdate = Find.TickManager.TicksGame;
                 if (largeFireActiveTicks >= GenDate.TicksPerDay * 10)
                 {
-                    SpawnWildMan(largeFire.Map);
+                    // Pick a random map from all active player fires to give all maps a chance to get the event.
+                    // If we just use the currently ticking fire it should (in theory) always trigger on the same map.
+                    var map = LargeFire.largeFires
+                        .Where(x => x.Map != null && x.lightOn && x.Faction.IsPlayer)
+                        .Select(x => x.Map)
+                        .Distinct()
+                        .RandomElement();
+                    // Use the currently ticking fire as a fallback in case something went really bad
+                    SpawnWildMan(map ?? largeFire.Map);
                     ResetLargeFireCounter();
                 }
             }

--- a/1.4/Source/Things/LargeFire.cs
+++ b/1.4/Source/Things/LargeFire.cs
@@ -51,7 +51,7 @@ namespace VFETribals
                     SetNextSparkTick();
                 }
                 GasUtility.AddGas(this.OccupiedRect().RandomCell, Map, GasType.BlindSmoke, 1);
-                if (Position.Roofed(Map) is false)
+                if (Position.Roofed(Map) is false && Faction.IsPlayer)
                 {
                     GameComponent_Tribals.Instance.IncrementLargeFireCounter(this);
                 }


### PR DESCRIPTION
First change is to only increment the large fire counter for player controlled fires. This will allow those fires to be used in custom non-player settlements and quests without interfering with player faction - mostly for compatibility with other mods that decide to use this building.

The second change is to spawn the wild pawn for a random map with a player controlled large fire, giving each map an equal chance to get the event. The current implementation will only ever spawn wild people on one map over and over (unless the fire was put out) due to everything always ticking in the same, deterministic order.