### PR TITLE
Fix large fire faction checks

### DIFF
--- a/1.4/Source/GameComponents/GameComponent_Tribals.cs
+++ b/1.4/Source/GameComponents/GameComponent_Tribals.cs
@@ -55,7 +55,7 @@ namespace VFETribals
                     // Pick a random map from all active player fires to give all maps a chance to get the event.
                     // If we just use the currently ticking fire it should (in theory) always trigger on the same map.
                     var map = LargeFire.largeFires
-                        .Where(x => x.Map != null && x.lightOn && x.Faction.IsPlayer)
+                        .Where(x => x.Map != null && x.lightOn && x.Faction == Faction.OfPlayer)
                         .Select(x => x.Map)
                         .Distinct()
                         .RandomElement();

--- a/1.4/Source/Things/LargeFire.cs
+++ b/1.4/Source/Things/LargeFire.cs
@@ -51,7 +51,7 @@ namespace VFETribals
                     SetNextSparkTick();
                 }
                 GasUtility.AddGas(this.OccupiedRect().RandomCell, Map, GasType.BlindSmoke, 1);
-                if (Position.Roofed(Map) is false && Faction.IsPlayer)
+                if (Position.Roofed(Map) is false && Faction == Faction.OfPlayer)
                 {
                     GameComponent_Tribals.Instance.IncrementLargeFireCounter(this);
                 }


### PR DESCRIPTION
I've realized that in my previous PR (#5) the player faction check will fail if the faction is not set/null due to (basically) calling `((Faction)null).IsPlayer`, causing `NullReferenceException`.

This will fix it by checking for faction using `thing.Faction == Faction.OfPlayer`.