### PR TITLE
Minor sitting spot improvements

### DIFF
--- a/1.4/Defs/ThingDefs_Buildings/Buildings_Furniture.xml
+++ b/1.4/Defs/ThingDefs_Buildings/Buildings_Furniture.xml
@@ -27,8 +27,14 @@
 			<artificialForMeditationPurposes>false</artificialForMeditationPurposes>
 			<canPlaceOverImpassablePlant>false</canPlaceOverImpassablePlant>
 			<ai_chillDestination>false</ai_chillDestination>
+			<!-- Don't destroy trees when putting a sitting spot over them -->
+			<sowTag>SupportPlantsOnly</sowTag>
+			<!-- Don't wake up dormant mechanoids when placed near them -->
+			<wakeDormantPawnsOnConstruction>false</wakeDormantPawnsOnConstruction>
 			
 		</building>
+		<!-- Prevent colonists from using sitting spots in prisons -->
+		<socialPropernessMatters>true</socialPropernessMatters>
 		
 	</ThingDef>
 </Defs>


### PR DESCRIPTION
Changes to sitting spots:
- Don't destroy trees (and other plants) when placed on top of them
- Don't wake up dormant mechanoids, preventing remotely waking them up
- Prevent colonists from using them in prisons

The first 2 changes are to match behaviour of vanilla spots, preventing exploits (instant tree removal, waking up mechanoids at any time). The last change was done to match behaviour of other chairs - it should ensure colonists use proper dining rooms (which are presumably of higher quality than a prison).

From what I see one difference between sitting spot and other spots (like sleeping spots) is `altitudeLayer` - other spots generally use `FloorEmplacement`. However, this is more of a design decision (they would draw under most plants, instead of over) so I left it unchanged.