### PR TITLE
Added inactive main map/no active maps fallback for ChoiceLetter_WildMenJoin

### DIFF
--- a/1.4/Source/UI/ChoiceLetter_WildMenJoin.cs
+++ b/1.4/Source/UI/ChoiceLetter_WildMenJoin.cs
@@ -16,6 +16,10 @@ namespace VFETribals
         {
             get
             {
+                var targetMap = map;
+                if (targetMap == null || !Find.Maps.Contains(targetMap))
+                    targetMap = Find.Maps.Where(x => x.IsPlayerHome).RandomElementWithFallback();
+
                 yield return new DiaOption("Accept".Translate())
                 {
                     action = () =>
@@ -26,7 +30,7 @@ namespace VFETribals
                         }
                         IncidentParms parms = new IncidentParms
                         {
-                            target = map
+                            target = targetMap
                         };
                         PawnsArrivalModeDef edgeWalkIn = PawnsArrivalModeDefOf.EdgeWalkIn;
                         edgeWalkIn.Worker.TryResolveRaidSpawnCenter(parms);
@@ -34,15 +38,16 @@ namespace VFETribals
                         Close();
                         this.quest.End(QuestEndOutcome.Success, false);
                     },
-                    resolveTree = true
+                    resolveTree = true,
+                    disabled = targetMap == null
                 };
                 yield return new DiaOption("VFET.Reject".Translate())
                 {
                     action = () =>
                     {
-                        if (Rand.Chance(0.2f))
+                        if (targetMap != null && Rand.Chance(0.2f))
                         {
-                            Utils.MakeWildmenRaid(wildmen, map);
+                            Utils.MakeWildmenRaid(wildmen, targetMap);
                             this.quest.End(QuestEndOutcome.Fail, false);
                         }
                         else


### PR DESCRIPTION
The ChoiceLetter will first check if the target map is null or not in the list of active maps. It'll then pick a random player home map (ignoring non-player home maps to avoid potential exploits, like spawning raids when rejecting on quest maps).

The accept option will only be active if there's any player map active. The reject option will always be available, but raids will only be possible if there's any player map.

The changes done here are to prevent issues when a player abandons the map the quest/letter was tied to, as well as an additional one if they abandon all their maps.